### PR TITLE
Matches git hashes from beginning. Fixes #1

### DIFF
--- a/ticketbot.py
+++ b/ticketbot.py
@@ -17,7 +17,7 @@ svn_changeset_re = re.compile(r'\br(\d+)\b')
 svn_changeset_re2 = re.compile(r'(?:^|\s)\[(\d+)\]')
 svn_changeset_url = "https://code.djangoproject.com/changeset/%s"
 
-github_sha_re = re.compile(r'\b[A-Fa-f0-9]{7,40}\b')
+github_sha_re = re.compile(r'\b^[A-Fa-f0-9]{7,40}\b')
 github_changeset_url = "https://github.com/django/django/commit/%s"
 
 


### PR DESCRIPTION
A possible solution to cut down on the number of false-positives. This requires that the user pastes the has as it's own word with nothing in front.
