### PR TITLE
Don't rewrite documentation links on #django-dev

### DIFF
--- a/ticketbot.py
+++ b/ticketbot.py
@@ -54,7 +54,10 @@ class TicketBot(irc.IRCClient):
         svn_changesets = set(svn_changeset_re.findall(msg)).union(
                          set(svn_changeset_re2.findall(msg)))
         github_changesets = set(github_sha_re.findall(msg))
-        dev_doc_links = set(dev_doc_re.findall(msg))
+        if not channel.endswith('-dev'):
+            dev_doc_links = set(dev_doc_re.findall(msg))
+        else:
+            dev_doc_links = []
 
         # Check to see if they're sending me a private message
         if channel == self.nickname:


### PR DESCRIPTION
On #django-dev, it's not very useful for ticketbot to rewrite links to the development documentation (a feature that I introduced a few months ago).

With this patch, ticketbot will not rewrite any documentation link if the channel's name ends with `-dev`.
